### PR TITLE
fix(oauth): Return nil instead of throwing Exception

### DIFF
--- a/src/happy/oauth2.clj
+++ b/src/happy/oauth2.clj
@@ -131,7 +131,8 @@
   (boolean (or refresh_token private_key)))
 
 (defn credential-scopes [credentials]
-  (str/split (:scope credentials) #" "))
+  (when (:scope credentials)
+    (str/split (:scope credentials) #" ")))
 
 (defn has-scopes? [credentials scopes]
   ;; TODO: scopes have a hierarchy


### PR DESCRIPTION
When authentication happens first time, there is no token file for the user. That causes NullPointerException to be thrown trying to split the string from nil where map with :scope is expected.
The calling function update-credentials, will then call :else clause in cond to properly follow auth flow and store new credentials. Now calling it again will work as expected