### PR TITLE
#6 feature: support random ports for the redirect URI

### DIFF
--- a/src/happy/oauth2_capture_redirect.clj
+++ b/src/happy/oauth2_capture_redirect.clj
@@ -14,19 +14,67 @@
     (catch Exception _
       nil)))
 
-(defn wait-for-redirect [{:as config :keys [redirect_uri redirect_uris]}]
+(defn redirect-uri->port
+  "Opening a browser and redirecting to a local server
+  only makes sense for localhost redirect-uris.
+
+  Known limitation: Google does not support no ipv6 [::1] with random ports"
+  [uri]
+  (let [[match protocol host _ port path] (re-find #"^(http://)(localhost|127.0.0.1)(:(\d+))?(/.*)?$" uri)
+        port (maybe-parse-int port)]
+    (if (not match)
+      (throw (RuntimeException. "URI doesn't match pattern"))
+      (or port
+          0)))) ;; Jetty's magic value 0 = random port
+
+(defn add-port
+  [uri random-port]
+  (let [[match protocol host _ port path] (re-find #"^(http://)(localhost|127.0.0.1)(:(\d+))?(/.*)?$" uri)]
+    (if (not match)
+      (throw (RuntimeException. "URI doesn't match pattern"))
+      (str protocol host ":" random-port path))))
+
+(defn query-string->params
+  "Converts an URI query-string a=b&c=d&e=f&...
+  into a param map {:a \"b\" :c \"d\" :e \"f\"}."
+  [q]
+  (let [split-by-& #(str/split % #"&")
+        split-by-= #(str/split % #"=")
+        pairs (map split-by-= (split-by-& q))
+        parameters (into {} (for [[k v] pairs]
+                              [(keyword k) v]))]
+    parameters))
+
+(defn wait-for-redirect
+  "wait-for-redirect takes a callback function and a Google client
+  config. The callback function will be called, when the jetty server
+  has been started. It receives a single argument with the effective
+  URI, i.e. the URI with the correct (maybe random) port."
+  [on-server-started-callback
+   {:as config :keys [redirect_uri redirect_uris]}]
   (let [code (promise)
-        port (or (some-> (or redirect_uri (last redirect_uris))
-                         (str/split #":")
-                         (last)
-                         (maybe-parse-int))
-                 80)
-        server (jetty/run-jetty
-                 (fn [request]
-                   (deliver code (some-> request :query-string (str/split #"=") second))
-                   {:status 200
-                    :body   "ok"})
-                 (merge {:port port :join? false} config))]
+        uri (or redirect_uri (last redirect_uris))
+        port (redirect-uri->port uri)
+        http-redirect-handler (fn [request]
+                                (deliver code (some-> request
+                                                      :query-string
+                                                      query-string->params
+                                                      :code))
+                                {:status 200
+                                 :body   "ok"})
+        server (jetty/run-jetty http-redirect-handler
+                                {:port port :join? false})
+        _ (.setStopTimeout server 1000) ;; wait 1000ms for graceful shutdown, to avoid races between stopping and returning the response
+        
+        ^org.eclipse.jetty.server.NetworkConnector
+        connector (-> server
+                      .getConnectors
+                      first)
+        effective-port (.getLocalPort connector)
+        effective-uri (if (= 0 port)
+                        (add-port uri effective-port)
+                        uri)]
+    (on-server-started-callback effective-uri)
     (-> (fn []
           (Thread/sleep 20000)
           (deliver code nil))
@@ -38,9 +86,13 @@
         (.stop server)))))
 
 (defn request-code [config scopes optional]
-  (-> (oauth2/set-authorization-parameters config scopes optional)
-      (browse/browse-url))
-  (wait-for-redirect config))
+  (let [on-server-started-callback (fn [uri]
+                                     (-> config
+                                         (dissoc :redirect_uri :redirect_uris)
+                                         (assoc :redirect_uri uri)
+                                         (oauth2/set-authorization-parameters scopes optional)
+                                         (browse/browse-url)))]
+    (wait-for-redirect on-server-started-callback config)))
 
 (defn update-credentials [config credentials scopes optional]
   ;; scopes can grow

--- a/src/happy/oauth2_credentials.clj
+++ b/src/happy/oauth2_credentials.clj
@@ -35,6 +35,8 @@
 (def *save (atom save-credentials))
 
 (defn auth!
+  "The default implementation of auth! relies on starting an ephemeral
+  local jetty server to receive the OAuth 2.0 token code."
   ([] (auth! "user"))
   ([user]
    (let [credentials (@*fetch user)

--- a/test/happy/oauth2_capture_redirect_test.clj
+++ b/test/happy/oauth2_capture_redirect_test.clj
@@ -5,9 +5,25 @@
             [happy.oauth2-credentials :as credentials]))
 
 (deftest wait-for-redirect-test
-  (-> (fn []
-        (Thread/sleep 100)
-        (http/get "http://localhost/redirect?code=CODE"))
-      (Thread. "redirect in a little while")
-      (.start))
-  (is (= "CODE" (r/wait-for-redirect {}))))
+  (is (= "CODE" (let [redirect-uri "http://localhost"
+                      simulate-redirect (fn [uri] (http/get (str uri "?code=CODE")))
+                      code (r/wait-for-redirect simulate-redirect {:redirect_uri redirect-uri})]
+                  code))))
+
+(deftest add-port-test
+  (do
+    (is (= "http://localhost:1234" (r/add-port "http://localhost" 1234)) "No path")
+    (is (= "http://localhost:1234/" (r/add-port "http://localhost/" 1234)) "Trailing slash")
+    (is (= "http://localhost:1234/bla/blubb" (r/add-port "http://localhost/bla/blubb" 1234)) "Path")
+    (is (= "http://localhost:1234/bla/blubb" (r/add-port "http://localhost:1234/bla/blubb" 1234)) "Port, path")
+    (is (thrown-with-msg? RuntimeException #"URI doesn't match pattern" (r/add-port "http://otherhost/bla/blubb" 1234)) "Not localhost")))
+
+(deftest redirect-uri->port-test
+  (do
+    (is (= 0 (r/redirect-uri->port "http://localhost")) "No port, no path")
+    (is (= 0 (r/redirect-uri->port "http://127.0.0.1")) "IPv4 address, no path")
+    (is (= 0 (r/redirect-uri->port "http://localhost/bla/blubb")) "Path, no port")
+    (is (= 1234 (r/redirect-uri->port "http://localhost:1234")) "Explicit port, no path")
+    (is (= 1234 (r/redirect-uri->port "http://localhost:1234/")) "Explicit port, trailing slash")
+    (is (= 1234 (r/redirect-uri->port "http://localhost:1234/bla/blubb")) "Explicit port, path")
+    (is (thrown-with-msg? RuntimeException #"URI doesn't match pattern" (r/redirect-uri->port "http://otherhost/bla/blubb")) "Not localhost")))

--- a/test/happygapi/youtube/videos_test.clj
+++ b/test/happygapi/youtube/videos_test.clj
@@ -1,4 +1,4 @@
-(ns happygapi.youtube.videos
+(ns happygapi.youtube.videos-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [happygapi.youtube.videos :as videos]


### PR DESCRIPTION
I tested localhost redirects with random-ports with webapp Google API credentials as well as with desktop app credentials. Google's behaviour seems to be the same in both cases.

Known issues of this PR:
* `happy.oauth2-credentials-test/auth!-test` is currently broken